### PR TITLE
Fix data races

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -3,188 +3,188 @@ package redis
 //// TODO: Document!
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
-    "sync"
-    "testing"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
 )
 
 func TestHashes(t *testing.T) {
-    println(HSet("my first hash", "my key", "yo yo yo"))
-    println(HGet("my first hash", "my key"))
+	println(HSet("my first hash", "my key", "yo yo yo"))
+	println(HGet("my first hash", "my key"))
 
-    println(HSet("my first hash", "my key", "xerg"))
-    println(HGet("my first hash", "my key"))
+	println(HSet("my first hash", "my key", "xerg"))
+	println(HGet("my first hash", "my key"))
 
-    println(HExists("my first hash", "not here"))
-    println(HExists("my first hash", "my key"))
+	println(HExists("my first hash", "not here"))
+	println(HExists("my first hash", "my key"))
 
-    println(HSet("my first hash", "his key", "doi"))
-    h := Hgetall("my first hash")
-    for k, v := range h {
-        println(k, ":", v)
-    }
+	println(HSet("my first hash", "his key", "doi"))
+	h := Hgetall("my first hash")
+	for k, v := range h {
+		println(k, ":", v)
+	}
 
-    //// Updating the returned hash's value shouldn't effect the source.
-    //
-    h["his key"] = "nuht uh"
-    for k, v := range Hgetall("my first hash") {
-        println(k, ":", v)
-    }
+	//// Updating the returned hash's value shouldn't effect the source.
+	//
+	h["his key"] = "nuht uh"
+	for k, v := range Hgetall("my first hash") {
+		println(k, ":", v)
+	}
 
-    for k, v := range Hkeys("my first hash") {
-        println(k, ":", v)
-    }
+	for k, v := range Hkeys("my first hash") {
+		println(k, ":", v)
+	}
 
-    for k, v := range Hvals("my first hash") {
-        println(k, ":", v)
-    }
+	for k, v := range Hvals("my first hash") {
+		println(k, ":", v)
+	}
 
 }
 
 func TestStrings(t *testing.T) {
-    println(Incr("my counter"))
-    println(Incr("my counter"))
-    println(Incr("my counter"))
-    println(Decr("my counter"))
-    println(Decr("my counter"))
-    println(Decr("my counter"))
-    println(Decr("my counter"))
+	println(Incr("my counter"))
+	println(Incr("my counter"))
+	println(Incr("my counter"))
+	println(Decr("my counter"))
+	println(Decr("my counter"))
+	println(Decr("my counter"))
+	println(Decr("my counter"))
 
-    println(Set("a string", "fun is ok"))
-    println(Get("a string"))
-    println(Set("a string", "fun is fun"))
-    println(Get("a string"))
-    println(Setnx("another string", "fresh"))
-    println(Get("another string"))
-    println(Setnx("another string", "not so fresh"))
-    println(Get("another string"))
+	println(Set("a string", "fun is ok"))
+	println(Get("a string"))
+	println(Set("a string", "fun is fun"))
+	println(Get("a string"))
+	println(Setnx("another string", "fresh"))
+	println(Get("another string"))
+	println(Setnx("another string", "not so fresh"))
+	println(Get("another string"))
 }
 
 func TestSets(t *testing.T) {
-    println(Sadd("a set", "A", "B", "C"))
-    println(Sadd("a set", "G", "F", "E", "D", "C", "B", "H"))
-    for k, v := range Smembers("a set") {
-        println(k, ":", v)
-    }
-    println(Scard("a set"))
+	println(Sadd("a set", "A", "B", "C"))
+	println(Sadd("a set", "G", "F", "E", "D", "C", "B", "H"))
+	for k, v := range Smembers("a set") {
+		println(k, ":", v)
+	}
+	println(Scard("a set"))
 }
 
 func TestLists(t *testing.T) {
-    println(Rpush("a list", "X", "Y", "Z"))
-    println(Rpush("a list", "G", "F", "E", "D", "C", "B"))
-    for k, v := range Lrange("a list", 1, -2) {
-        println(k, ":", v)
-    }
-    for k, v := range Lrange("a list", -5, -3) {
-        println(k, ":", v)
-    }
-    for k, v := range Lrange("a list", -5, -6) {
-        println(k, ":", v)
-    }
-    println(Llen("a list"))
+	println(Rpush("a list", "X", "Y", "Z"))
+	println(Rpush("a list", "G", "F", "E", "D", "C", "B"))
+	for k, v := range Lrange("a list", 1, -2) {
+		println(k, ":", v)
+	}
+	for k, v := range Lrange("a list", -5, -3) {
+		println(k, ":", v)
+	}
+	for k, v := range Lrange("a list", -5, -6) {
+		println(k, ":", v)
+	}
+	println(Llen("a list"))
 }
 
 func TestKeys(t *testing.T) {
-    println(Rpush("a list", "X", "Y", "Z"))
-    println(Exists("a list"))
-    println(Type("a list"))
-    println(Del("a list"))
-    println(Exists("a list"))
+	println(Rpush("a list", "X", "Y", "Z"))
+	println(Exists("a list"))
+	println(Type("a list"))
+	println(Del("a list"))
+	println(Exists("a list"))
 
-    println(Incr("my counter"))
-    println(HSet("my first hash", "my key", "yo yo yo"))
-    println(Rpush("a list", "A", "B", "C"))
-    println(Set("a string", "fun is ok"))
-    println(Sadd("a set", "X", "Y", "X"))
+	println(Incr("my counter"))
+	println(HSet("my first hash", "my key", "yo yo yo"))
+	println(Rpush("a list", "A", "B", "C"))
+	println(Set("a string", "fun is ok"))
+	println(Sadd("a set", "X", "Y", "X"))
 
-    for k, v := range Keys(".*") {
-        println(k, ":", v)
-    }
+	for k, v := range Keys(".*") {
+		println(k, ":", v)
+	}
 }
 
 func TestServer(t *testing.T) {
-    println(Incr("my counter"))
-    println(HSet("my first hash", "my key", "yo yo yo"))
-    println(Rpush("a list", "A", "B", "C"))
-    println(Set("a string", "fun is ok"))
-    println(Sadd("a set", "X", "Y", "X"))
+	println(Incr("my counter"))
+	println(HSet("my first hash", "my key", "yo yo yo"))
+	println(Rpush("a list", "A", "B", "C"))
+	println(Set("a string", "fun is ok"))
+	println(Sadd("a set", "X", "Y", "X"))
 
-    complete := make(chan bool)
-    tmpDir := os.TempDir()
-    baseFileName := fmt.Sprintf("localRedisTest.%d.json", os.Getpid())
-    fileName := filepath.Join(tmpDir, baseFileName)
-    println(BgSave(fileName, complete))
-    <-complete
+	complete := make(chan bool)
+	tmpDir := os.TempDir()
+	baseFileName := fmt.Sprintf("localRedisTest.%d.json", os.Getpid())
+	fileName := filepath.Join(tmpDir, baseFileName)
+	println(BgSave(fileName, complete))
+	<-complete
 }
 
 func TestPubSubSimple(t *testing.T) {
-    var w sync.WaitGroup
-    w.Add(2)
-    consumer := Psubscribe(".*first.*")
+	var w sync.WaitGroup
+	w.Add(2)
+	consumer := Psubscribe(".*first.*")
 
-    go func() {
-        match := <-consumer.Channel
-        println("Match on second consumer:", match.TypeName, match.KeyName, match.Data.(Hash)["my key"])
-        w.Done()
-    }()
+	go func() {
+		match := <-consumer.Channel
+		println("Match on second consumer:", match.TypeName, match.KeyName, match.Data.(Hash)["my key"])
+		w.Done()
+	}()
 
-    go func() {
-        println("Setting hash val")
-        println(HSet("my first hash", "my key", "yo yo yo"))
-        println("Set hash val")
-        w.Done()
-    }()
+	go func() {
+		println("Setting hash val")
+		println(HSet("my first hash", "my key", "yo yo yo"))
+		println("Set hash val")
+		w.Done()
+	}()
 
-    w.Wait()
+	w.Wait()
 }
 
 func TestPubSubMultiple(t *testing.T) {
-    var w sync.WaitGroup
-    w.Add(3)
+	var w sync.WaitGroup
+	w.Add(3)
 
-    go func() {
-        consumer := Psubscribe("my first hash", ".*list.*")
+	go func() {
+		consumer := Psubscribe("my first hash", ".*list.*")
 
-        go func() {
-            println(Rpush("a list", "item 1", "item 2"))
-            println(HSet("my first hash", "my key", "yo yo yo"))
-            w.Done()
-        }()
+		go func() {
+			println(Rpush("a list", "item 1", "item 2"))
+			println(HSet("my first hash", "my key", "yo yo yo"))
+			w.Done()
+		}()
 
-        for notice := range consumer.Channel {
+		for notice := range consumer.Channel {
 
-            switch data := notice.Data.(type) {
-            case List:
-                println("Match on consumer:", notice.TypeName, notice.KeyName, data[1])
-                w.Done()
-            case Hash:
-                println("Match on consumer:", notice.TypeName, notice.KeyName, data["my key"])
-                w.Done()
-            }
+			switch data := notice.Data.(type) {
+			case List:
+				println("Match on consumer:", notice.TypeName, notice.KeyName, data[1])
+				w.Done()
+			case Hash:
+				println("Match on consumer:", notice.TypeName, notice.KeyName, data.Get("my key"))
+				w.Done()
+			}
 
-        }
-    }()
+		}
+	}()
 
-    w.Wait()
+	w.Wait()
 }
 
 func TestPubSubRedisSetUpdates(t *testing.T) {
-    var w sync.WaitGroup
-    w.Add(1)
+	var w sync.WaitGroup
+	w.Add(1)
 
-    consumer := Psubscribe("publish set")
+	consumer := Psubscribe("publish set")
 
-    go func() {
-        println("Setting set vals")
-        println(Sadd("publish set", "hot", "doggie"))
-        println("Set set vals")
-        w.Done()
-    }()
+	go func() {
+		println("Setting set vals")
+		println(Sadd("publish set", "hot", "doggie"))
+		println("Set set vals")
+		w.Done()
+	}()
 
-    match := <-consumer.Channel
-    println("Match on second consumer:", match.TypeName, match.KeyName, match.Data.([]string)[0], match.Data.([]string)[1])
+	match := <-consumer.Channel
+	println("Match on second consumer:", match.TypeName, match.KeyName, match.Data.([]string)[0], match.Data.([]string)[1])
 
-    w.Wait()
+	w.Wait()
 }

--- a/all_test.go
+++ b/all_test.go
@@ -22,14 +22,14 @@ func TestHashes(t *testing.T) {
 
 	println(HSet("my first hash", "his key", "doi"))
 	h := Hgetall("my first hash")
-	for k, v := range h {
+	for k, v := range h.ToMap() {
 		println(k, ":", v)
 	}
 
 	//// Updating the returned hash's value shouldn't effect the source.
 	//
-	h["his key"] = "nuht uh"
-	for k, v := range Hgetall("my first hash") {
+	h.Set("his key", "nuht uh")
+	for k, v := range Hgetall("my first hash").ToMap() {
 		println(k, ":", v)
 	}
 
@@ -126,7 +126,8 @@ func TestPubSubSimple(t *testing.T) {
 
 	go func() {
 		match := <-consumer.Channel
-		println("Match on second consumer:", match.TypeName, match.KeyName, match.Data.(Hash)["my key"])
+		hash := match.Data.(Hash)
+		println("Match on second consumer:", match.TypeName, match.KeyName, hash.Get("my key"))
 		w.Done()
 	}()
 

--- a/hashes.go
+++ b/hashes.go
@@ -6,8 +6,8 @@ import "sync"
 type Hash map[string]string
 
 var (
-    allHashes map[string]Hash = make(map[string]Hash)
-    hashesMu  sync.RWMutex
+	allHashes map[string]Hash = make(map[string]Hash)
+	hashesMu  sync.RWMutex
 )
 
 // Sets field in the hash stored at key to value. If key does not exist, a
@@ -19,21 +19,21 @@ var (
 // 1 if field is a new field in the hash and value was set.
 // 0 if field already exists in the hash and the value was updated.
 func HSet(key, field, value string) (existed int) {
-    hashesMu.Lock()
-    defer hashesMu.Unlock()
+	hashesMu.Lock()
+	defer hashesMu.Unlock()
 
-    existed = 0
-    h, exists := allHashes[key]
-    if !exists {
-        allHashes[key] = Hash{}
-        h = allHashes[key]
-        existed = 1
-    }
-    h[field] = value
+	existed = 0
+	h, exists := allHashes[key]
+	if !exists {
+		allHashes[key] = Hash{}
+		h = allHashes[key]
+		existed = 1
+	}
+	h[field] = value
 
-    publish <- notice{"hash", key, field, allHashes[key]}
+	publish <- notice{"hash", key, field, allHashes[key]}
 
-    return
+	return
 }
 
 // Returns the value associated with field in the hash stored at key.
@@ -42,11 +42,11 @@ func HSet(key, field, value string) (existed int) {
 // Bulk string reply: the value associated with field, or nil when field is not
 // present in the hash or key does not exist.
 func HGet(key, field string) string {
-    hashesMu.RLock()
-    defer hashesMu.RUnlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-    h := allHashes[key]
-    return h[field]
+	h := allHashes[key]
+	return h[field]
 }
 
 // Removes the specified fields from the hash stored at key. Specified fields that do not
@@ -57,22 +57,22 @@ func HGet(key, field string) string {
 // Integer reply: the number of fields that were removed from the hash, not including
 // specified but non existing fields.
 func HDel(key, field string) (existed int) {
-    hashesMu.Lock()
-    defer hashesMu.Unlock()
+	hashesMu.Lock()
+	defer hashesMu.Unlock()
 
-    existed = 0
-    h, exists := allHashes[key]
-    if exists {
-        _, exists := h[field]
-        if exists {
-            delete(h, field)
-            existed++
-        }
-    }
+	existed = 0
+	h, exists := allHashes[key]
+	if exists {
+		_, exists := h[field]
+		if exists {
+			delete(h, field)
+			existed++
+		}
+	}
 
-    publish <- notice{"hash", key, field, allHashes[key]}
+	publish <- notice{"hash", key, field, allHashes[key]}
 
-    return
+	return
 }
 
 // Returns if field is an existing field in the hash stored at key.
@@ -82,20 +82,20 @@ func HDel(key, field string) (existed int) {
 // 1 if the hash contains field.
 // 0 if the hash does not contain field, or key does not exist.
 func HExists(key, field string) (existed int) {
-    hashesMu.RLock()
-    defer hashesMu.RUnlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-    existed = 0
+	existed = 0
 
-    h, hash_exists := allHashes[key]
-    if hash_exists {
-        _, field_exists := h[field]
-        if field_exists {
-            existed = 1
-        }
-    }
+	h, hash_exists := allHashes[key]
+	if hash_exists {
+		_, field_exists := h[field]
+		if field_exists {
+			existed = 1
+		}
+	}
 
-    return
+	return
 }
 
 // Returns all fields and values of the hash stored at key. In the returned
@@ -105,24 +105,24 @@ func HExists(key, field string) (existed int) {
 // Return value
 // map[string]string reply: list of fields and their values stored in the hash, or an empty list when key does not exist.
 func Hgetall(key string) (out Hash) {
-    hashesMu.RLock()
-    defer hashesMu.RUnlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-    out = Hash{}
+	out = Hash{}
 
-    h, _ := allHashes[key]
-    for k, v := range h {
-        out[k] = v
-    }
+	h, _ := allHashes[key]
+	for k, v := range h {
+		out[k] = v
+	}
 
-    return
+	return
 }
 
 func HToJSON(data interface{}) ([]byte, error) {
     hashesMu.RLock()
     defer hashesMu.RUnlock()
 	b, err := json.Marshal(data)
-    return b, err
+	return b, err
 }
 
 // Returns all values in the hash stored at key.
@@ -130,15 +130,15 @@ func HToJSON(data interface{}) ([]byte, error) {
 // Return value
 // Slice reply: list of values in the hash, or an empty list when key does not exist.
 func Hvals(key string) (out []string) {
-    hashesMu.RLock()
-    defer hashesMu.RUnlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-    h, _ := allHashes[key]
-    for _, v := range h {
-        out = append(out, v)
-    }
+	h, _ := allHashes[key]
+	for _, v := range h {
+		out = append(out, v)
+	}
 
-    return
+	return
 }
 
 // Returns all field names in the hash stored at key.
@@ -146,13 +146,13 @@ func Hvals(key string) (out []string) {
 // Return value
 // Array reply: list of fields in the hash, or an empty list when key does not exist.
 func Hkeys(key string) (out []string) {
-    hashesMu.RLock()
-    defer hashesMu.RUnlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-    h, _ := allHashes[key]
-    for k, _ := range h {
-        out = append(out, k)
-    }
+	h, _ := allHashes[key]
+	for k, _ := range h {
+		out = append(out, k)
+	}
 
-    return
+	return
 }

--- a/hashes.go
+++ b/hashes.go
@@ -119,8 +119,6 @@ func Hgetall(key string) (out Hash) {
 }
 
 func HToJSON(data interface{}) ([]byte, error) {
-    hashesMu.RLock()
-    defer hashesMu.RUnlock()
 	b, err := json.Marshal(data)
 	return b, err
 }

--- a/hashes.go
+++ b/hashes.go
@@ -1,14 +1,122 @@
 package redis
 
-import "encoding/json"
 import "sync"
 
-type Hash map[string]string
-
 var (
-	allHashes map[string]Hash = make(map[string]Hash)
+	allHashes = make(map[string]Hash)
 	hashesMu  sync.RWMutex
 )
+
+// Hash is a concurrent safe string map
+type Hash struct {
+	m  map[string]string
+	mu *sync.RWMutex
+}
+
+// NewHash creates a new Hash
+func NewHash() Hash {
+	return Hash{
+		m:  make(map[string]string),
+		mu: new(sync.RWMutex),
+	}
+}
+
+// Size returns the number of items in the hash
+func (h Hash) Size() int {
+	h.mu.RLock()
+	size := len(h.m)
+	h.mu.RUnlock()
+	return size
+}
+
+// Exists returns whether a key exists in the hash
+func (h Hash) Exists(key string) bool {
+	h.mu.RLock()
+	_, ok := h.m[key]
+	h.mu.RUnlock()
+	return ok
+}
+
+// Get returns the value of a key in the map,
+// or an empty string if it doesn't exist
+func (h Hash) Get(key string) string {
+	h.mu.RLock()
+	val := h.m[key]
+	h.mu.RUnlock()
+	return val
+}
+
+// GetExists returns the value of a key in the map,
+// and whether it existed.
+func (h Hash) GetExists(key string) (string, bool) {
+	h.mu.RLock()
+	val, exists := h.m[key]
+	h.mu.RUnlock()
+	return val, exists
+}
+
+// Set a key to a value
+func (h Hash) Set(key, value string) {
+	h.mu.Lock()
+	h.m[key] = value
+	h.mu.Unlock()
+}
+
+// Delete a key in the hash
+func (h Hash) Delete(key string) {
+	h.mu.Lock()
+	delete(h.m, key)
+	h.mu.Unlock()
+}
+
+// Keys returns all keys in the hash
+func (h Hash) Keys() []string {
+	h.mu.RLock()
+	keys := make([]string, 0, len(h.m))
+	for k := range h.m {
+		keys = append(keys, k)
+	}
+	h.mu.RUnlock()
+
+	return keys
+}
+
+// Values returns all values in the hash
+func (h Hash) Values() []string {
+	h.mu.RLock()
+	values := make([]string, 0, len(h.m))
+	for _, v := range h.m {
+		values = append(values, v)
+	}
+	h.mu.RUnlock()
+
+	return values
+}
+
+// Copy keys and values to a new Hash
+func (h Hash) Copy() Hash {
+	newHash := NewHash()
+
+	h.mu.RLock()
+	for k, v := range h.m {
+		newHash.m[k] = v
+	}
+	h.mu.RUnlock()
+
+	return newHash
+}
+
+// ToMap returns a copy of all data in the hash, as a map
+func (h Hash) ToMap() map[string]string {
+	h.mu.RLock()
+	retMap := make(map[string]string, len(h.m))
+	for k, v := range h.m {
+		retMap[k] = v
+	}
+	h.mu.RUnlock()
+
+	return retMap
+}
 
 // Sets field in the hash stored at key to value. If key does not exist, a
 // new key holding a hash is created. If field already exists in the hash,
@@ -20,18 +128,20 @@ var (
 // 0 if field already exists in the hash and the value was updated.
 func HSet(key, field, value string) (existed int) {
 	hashesMu.Lock()
-	defer hashesMu.Unlock()
 
 	existed = 0
 	h, exists := allHashes[key]
 	if !exists {
-		allHashes[key] = Hash{}
-		h = allHashes[key]
+		h = NewHash()
+		allHashes[key] = h
 		existed = 1
 	}
-	h[field] = value
 
-	publish <- notice{"hash", key, field, allHashes[key]}
+	hashesMu.Unlock()
+
+	h.Set(field, value)
+
+	publish <- notice{"hash", key, field, h}
 
 	return
 }
@@ -43,10 +153,14 @@ func HSet(key, field, value string) (existed int) {
 // present in the hash or key does not exist.
 func HGet(key, field string) string {
 	hashesMu.RLock()
-	defer hashesMu.RUnlock()
+	h, ok := allHashes[key]
+	hashesMu.RUnlock()
 
-	h := allHashes[key]
-	return h[field]
+	if !ok {
+		return ""
+	}
+
+	return h.Get(field)
 }
 
 // Removes the specified fields from the hash stored at key. Specified fields that do not
@@ -58,19 +172,20 @@ func HGet(key, field string) string {
 // specified but non existing fields.
 func HDel(key, field string) (existed int) {
 	hashesMu.Lock()
-	defer hashesMu.Unlock()
 
 	existed = 0
 	h, exists := allHashes[key]
+
 	if exists {
-		_, exists := h[field]
-		if exists {
-			delete(h, field)
+		if h.Exists(field) {
+			h.Delete(field)
 			existed++
 		}
 	}
 
-	publish <- notice{"hash", key, field, allHashes[key]}
+	hashesMu.Unlock()
+
+	publish <- notice{"hash", key, field, h}
 
 	return
 }
@@ -83,14 +198,13 @@ func HDel(key, field string) (existed int) {
 // 0 if the hash does not contain field, or key does not exist.
 func HExists(key, field string) (existed int) {
 	hashesMu.RLock()
-	defer hashesMu.RUnlock()
+	h, hashExists := allHashes[key]
+	hashesMu.RUnlock()
 
 	existed = 0
 
-	h, hash_exists := allHashes[key]
-	if hash_exists {
-		_, field_exists := h[field]
-		if field_exists {
+	if hashExists {
+		if h.Exists(field) {
 			existed = 1
 		}
 	}
@@ -104,53 +218,46 @@ func HExists(key, field string) (existed int) {
 //
 // Return value
 // map[string]string reply: list of fields and their values stored in the hash, or an empty list when key does not exist.
-func Hgetall(key string) (out Hash) {
+func Hgetall(key string) Hash {
 	hashesMu.RLock()
-	defer hashesMu.RUnlock()
+	h, ok := allHashes[key]
+	hashesMu.RUnlock()
 
-	out = Hash{}
-
-	h, _ := allHashes[key]
-	for k, v := range h {
-		out[k] = v
+	if !ok {
+		return NewHash()
 	}
 
-	return
-}
-
-func HToJSON(data interface{}) ([]byte, error) {
-	b, err := json.Marshal(data)
-	return b, err
+	return h.Copy()
 }
 
 // Returns all values in the hash stored at key.
 //
 // Return value
 // Slice reply: list of values in the hash, or an empty list when key does not exist.
-func Hvals(key string) (out []string) {
+func Hvals(key string) []string {
 	hashesMu.RLock()
-	defer hashesMu.RUnlock()
+	h, ok := allHashes[key]
+	hashesMu.RUnlock()
 
-	h, _ := allHashes[key]
-	for _, v := range h {
-		out = append(out, v)
+	if !ok {
+		return []string{}
 	}
 
-	return
+	return h.Values()
 }
 
 // Returns all field names in the hash stored at key.
 //
 // Return value
 // Array reply: list of fields in the hash, or an empty list when key does not exist.
-func Hkeys(key string) (out []string) {
+func Hkeys(key string) []string {
 	hashesMu.RLock()
-	defer hashesMu.RUnlock()
+	h, ok := allHashes[key]
+	hashesMu.RUnlock()
 
-	h, _ := allHashes[key]
-	for k, _ := range h {
-		out = append(out, k)
+	if !ok {
+		return []string{}
 	}
 
-	return
+	return h.Keys()
 }

--- a/keys.go
+++ b/keys.go
@@ -60,17 +60,17 @@ func Del(key ...string) (deletedCount int) {
 // 0 if the key does not exist.
 func Exists(key string) int {
 
-	hashesMu.Lock()
-	defer hashesMu.Unlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-	listsMu.Lock()
-	defer listsMu.Unlock()
+	listsMu.RLock()
+	defer listsMu.RUnlock()
 
-	setsMu.Lock()
-	defer setsMu.Unlock()
+	setsMu.RLock()
+	defer setsMu.RUnlock()
 
-	stringsMu.Lock()
-	defer stringsMu.Unlock()
+	stringsMu.RLock()
+	defer stringsMu.RUnlock()
 
 	if _, exists := allHashes[key]; exists {
 		return 1
@@ -95,17 +95,17 @@ func Exists(key string) int {
 // Simple string reply: type of key, or none when key does not exist.
 func Type(key string) string {
 
-	hashesMu.Lock()
-	defer hashesMu.Unlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-	listsMu.Lock()
-	defer listsMu.Unlock()
+	listsMu.RLock()
+	defer listsMu.RUnlock()
 
-	setsMu.Lock()
-	defer setsMu.Unlock()
+	setsMu.RLock()
+	defer setsMu.RUnlock()
 
-	stringsMu.Lock()
-	defer stringsMu.Unlock()
+	stringsMu.RLock()
+	defer stringsMu.RUnlock()
 
 	if _, exists := allHashes[key]; exists {
 		return "hash"
@@ -144,17 +144,17 @@ func Type(key string) string {
 // Array reply: list of keys matching pattern.
 func Keys(pattern string) (out []string) {
 
-	hashesMu.Lock()
-	defer hashesMu.Unlock()
+	hashesMu.RLock()
+	defer hashesMu.RUnlock()
 
-	listsMu.Lock()
-	defer listsMu.Unlock()
+	listsMu.RLock()
+	defer listsMu.RUnlock()
 
-	setsMu.Lock()
-	defer setsMu.Unlock()
+	setsMu.RLock()
+	defer setsMu.RUnlock()
 
-	stringsMu.Lock()
-	defer stringsMu.Unlock()
+	stringsMu.RLock()
+	defer stringsMu.RUnlock()
 
 	r, _ := regexp.Compile(pattern)
 

--- a/keys.go
+++ b/keys.go
@@ -8,48 +8,48 @@ import "regexp"
 // Integer reply: The number of keys that were removed.
 func Del(key ...string) (deletedCount int) {
 
-    hashesMu.Lock()
-    defer hashesMu.Unlock()
+	hashesMu.Lock()
+	defer hashesMu.Unlock()
 
-    listsMu.Lock()
-    defer listsMu.Unlock()
+	listsMu.Lock()
+	defer listsMu.Unlock()
 
-    setsMu.Lock()
-    defer setsMu.Unlock()
+	setsMu.Lock()
+	defer setsMu.Unlock()
 
-    stringsMu.Lock()
-    defer stringsMu.Unlock()
+	stringsMu.Lock()
+	defer stringsMu.Unlock()
 
-    deletedCount = 0
+	deletedCount = 0
 
-    for _, k := range key {
-        if _, exists := allHashes[k]; exists {
-            delete(allHashes, k)
-            deletedCount++
-            publish <- notice{"hash", k, "", nil}
-            continue
-        }
-        if _, exists := allLists[k]; exists {
-            delete(allLists, k)
-            deletedCount++
-            publish <- notice{"list", k, "", nil}
-            continue
-        }
-        if _, exists := allSets[k]; exists {
-            delete(allSets, k)
-            deletedCount++
-            publish <- notice{"set", k, "", nil}
-            continue
-        }
-        if _, exists := allStrings[k]; exists {
-            delete(allStrings, k)
-            deletedCount++
-            publish <- notice{"string", k, "", nil}
-            continue
-        }
-    }
+	for _, k := range key {
+		if _, exists := allHashes[k]; exists {
+			delete(allHashes, k)
+			deletedCount++
+			publish <- notice{"hash", k, "", nil}
+			continue
+		}
+		if _, exists := allLists[k]; exists {
+			delete(allLists, k)
+			deletedCount++
+			publish <- notice{"list", k, "", nil}
+			continue
+		}
+		if _, exists := allSets[k]; exists {
+			delete(allSets, k)
+			deletedCount++
+			publish <- notice{"set", k, "", nil}
+			continue
+		}
+		if _, exists := allStrings[k]; exists {
+			delete(allStrings, k)
+			deletedCount++
+			publish <- notice{"string", k, "", nil}
+			continue
+		}
+	}
 
-    return
+	return
 }
 
 // Returns if key exists.
@@ -60,32 +60,32 @@ func Del(key ...string) (deletedCount int) {
 // 0 if the key does not exist.
 func Exists(key string) int {
 
-    hashesMu.Lock()
-    defer hashesMu.Unlock()
+	hashesMu.Lock()
+	defer hashesMu.Unlock()
 
-    listsMu.Lock()
-    defer listsMu.Unlock()
+	listsMu.Lock()
+	defer listsMu.Unlock()
 
-    setsMu.Lock()
-    defer setsMu.Unlock()
+	setsMu.Lock()
+	defer setsMu.Unlock()
 
-    stringsMu.Lock()
-    defer stringsMu.Unlock()
+	stringsMu.Lock()
+	defer stringsMu.Unlock()
 
-    if _, exists := allHashes[key]; exists {
-        return 1
-    }
-    if _, exists := allLists[key]; exists {
-        return 1
-    }
-    if _, exists := allSets[key]; exists {
-        return 1
-    }
-    if _, exists := allStrings[key]; exists {
-        return 1
-    }
+	if _, exists := allHashes[key]; exists {
+		return 1
+	}
+	if _, exists := allLists[key]; exists {
+		return 1
+	}
+	if _, exists := allSets[key]; exists {
+		return 1
+	}
+	if _, exists := allStrings[key]; exists {
+		return 1
+	}
 
-    return 0
+	return 0
 }
 
 // Returns the string representation of the type of the value stored at key. The different
@@ -95,32 +95,32 @@ func Exists(key string) int {
 // Simple string reply: type of key, or none when key does not exist.
 func Type(key string) string {
 
-    hashesMu.Lock()
-    defer hashesMu.Unlock()
+	hashesMu.Lock()
+	defer hashesMu.Unlock()
 
-    listsMu.Lock()
-    defer listsMu.Unlock()
+	listsMu.Lock()
+	defer listsMu.Unlock()
 
-    setsMu.Lock()
-    defer setsMu.Unlock()
+	setsMu.Lock()
+	defer setsMu.Unlock()
 
-    stringsMu.Lock()
-    defer stringsMu.Unlock()
+	stringsMu.Lock()
+	defer stringsMu.Unlock()
 
-    if _, exists := allHashes[key]; exists {
-        return "hash"
-    }
-    if _, exists := allLists[key]; exists {
-        return "list"
-    }
-    if _, exists := allSets[key]; exists {
-        return "set"
-    }
-    if _, exists := allStrings[key]; exists {
-        return "string"
-    }
+	if _, exists := allHashes[key]; exists {
+		return "hash"
+	}
+	if _, exists := allLists[key]; exists {
+		return "list"
+	}
+	if _, exists := allSets[key]; exists {
+		return "set"
+	}
+	if _, exists := allStrings[key]; exists {
+		return "string"
+	}
 
-    return ""
+	return ""
 }
 
 // Returns all keys matching pattern.
@@ -144,43 +144,43 @@ func Type(key string) string {
 // Array reply: list of keys matching pattern.
 func Keys(pattern string) (out []string) {
 
-    hashesMu.Lock()
-    defer hashesMu.Unlock()
+	hashesMu.Lock()
+	defer hashesMu.Unlock()
 
-    listsMu.Lock()
-    defer listsMu.Unlock()
+	listsMu.Lock()
+	defer listsMu.Unlock()
 
-    setsMu.Lock()
-    defer setsMu.Unlock()
+	setsMu.Lock()
+	defer setsMu.Unlock()
 
-    stringsMu.Lock()
-    defer stringsMu.Unlock()
+	stringsMu.Lock()
+	defer stringsMu.Unlock()
 
-    r, _ := regexp.Compile(pattern)
+	r, _ := regexp.Compile(pattern)
 
-    for k, _ := range allHashes {
-        if r.MatchString(k) == true {
-            out = append(out, k)
-        }
-    }
+	for k, _ := range allHashes {
+		if r.MatchString(k) == true {
+			out = append(out, k)
+		}
+	}
 
-    for k, _ := range allLists {
-        if r.MatchString(k) == true {
-            out = append(out, k)
-        }
-    }
+	for k, _ := range allLists {
+		if r.MatchString(k) == true {
+			out = append(out, k)
+		}
+	}
 
-    for k, _ := range allSets {
-        if r.MatchString(k) == true {
-            out = append(out, k)
-        }
-    }
+	for k, _ := range allSets {
+		if r.MatchString(k) == true {
+			out = append(out, k)
+		}
+	}
 
-    for k, _ := range allStrings {
-        if r.MatchString(k) == true {
-            out = append(out, k)
-        }
-    }
+	for k, _ := range allStrings {
+		if r.MatchString(k) == true {
+			out = append(out, k)
+		}
+	}
 
-    return
+	return
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -3,19 +3,19 @@ package redis
 import "regexp"
 
 type notice struct {
-    TypeName, KeyName, FieldName string
-    Data              interface{}
+	TypeName, KeyName, FieldName string
+	Data                         interface{}
 }
 
 type consumer struct {
-    exps    []*regexp.Regexp
-    Channel chan notice
+	exps    []*regexp.Regexp
+	Channel chan notice
 }
 
 var (
-    publish      = make(chan notice, 1000)
-    consumers    []consumer
-    publishCount = 0
+	publish      = make(chan notice, 1000)
+	consumers    []consumer
+	publishCount = 0
 )
 
 // Subscribes the client to the given patterns.
@@ -24,31 +24,31 @@ var (
 // h*llo subscribes to hllo and heeeello
 // h[ae]llo subscribes to hello and hallo, but not hillo
 // Use \ to escape special characters if you want to match them verbatim.
-func Psubscribe(pattern ...string) (c consumer) {
-    exps := []*regexp.Regexp{}
+func Psubscribe(pattern ...string) consumer {
+	exps := []*regexp.Regexp{}
 
-    for _, p := range pattern {
-        r, _ := regexp.Compile(p)
-        exps = append(exps, r)
-    }
-    c = consumer{exps: exps, Channel: make(chan notice, 1000)}
-    consumers = append(consumers, c)
+	for _, p := range pattern {
+		r, _ := regexp.Compile(p)
+		exps = append(exps, r)
+	}
+	c = consumer{exps: exps, Channel: make(chan notice, 1000)}
+	consumers = append(consumers, c)
 
-    return
+	return
 }
 
 func init() {
-    go func() {
-        for v := range publish {
-            for _, c := range consumers {
-                for _, r := range c.exps {
-                    if r.MatchString(v.KeyName) == true {
-                        // fmt.Println("Publishing:", v.KeyName)
-                        c.Channel <- v
-                    }
-                }
-            }
-            publishCount++
-        }
-    }()
+	go func() {
+		for v := range publish {
+			for _, c := range consumers {
+				for _, r := range c.exps {
+					if r.MatchString(v.KeyName) == true {
+						// fmt.Println("Publishing:", v.KeyName)
+						c.Channel <- v
+					}
+				}
+			}
+			publishCount++
+		}
+	}()
 }

--- a/server.go
+++ b/server.go
@@ -1,16 +1,16 @@
 package redis
 
 import (
-    "bufio"
-    "encoding/json"
-    "os"
-    "sync"
+	"bufio"
+	"encoding/json"
+	"os"
+	"sync"
 )
 
 var (
-    lastPublishCount = 0
-    DefaultDumpFileName     = "../redisServer.dump.json"
-    fileWriteMu      sync.Mutex
+	lastPublishCount = 0
+	DefaultDumpFileName       = "../redisServer.dump.json"
+	fileWriteMu        sync.Mutex
 )
 
 // Save the DB in background. The OK code is immediately returned. Redis forks, the parent
@@ -21,94 +21,94 @@ var (
 // Return value
 // Simple string reply
 func BgSave(fileName string, complete chan bool) string {
-    if publishCount > lastPublishCount {
-        lastPublishCount = publishCount
+	if publishCount > lastPublishCount
+	if pubCount > lastPublishCount {
 
-        go func() {
-            fileWriteMu.Lock()
-            defer fileWriteMu.Unlock()
+		go func() {
+			fileWriteMu.Lock()
+			defer fileWriteMu.Unlock()
 
-            fo, _ := os.Create(fileName)
-            defer fo.Close()
-            w := bufio.NewWriter(fo)
+			fo, _ := os.Create(fileName)
+			defer fo.Close()
+			w := bufio.NewWriter(fo)
 
-            // TODO: Lock around each key (checking existence) instead of around the whole
-            // hash so that other operations may sneak in.
+			// TODO: Lock around each key (checking existence) instead of around the whole
+			// hash so that other operations may sneak in.
 
-            hashesMu.Lock()
-            b1, err := json.MarshalIndent(&allHashes, "", "    ")
-            if err != nil {
-                println(err.Error())
-                return
-            }
-            w.Write(b1)
-            hashesMu.Unlock()
+			hashesMu.Lock()
+			b1, err := json.MarshalIndent(&allHashes, "", "    ")
+			if err != nil {
+				println(err.Error())
+				return
+			}
+			w.Write(b1)
+			hashesMu.Unlock()
 
-            listsMu.Lock()
-            b2, err := json.MarshalIndent(&allLists, "", "    ")
-            if err != nil {
-                println(err.Error())
-                return
-            }
-            w.Write(b2)
-            listsMu.Unlock()
+			listsMu.Lock()
+			b2, err := json.MarshalIndent(&allLists, "", "    ")
+			if err != nil {
+				println(err.Error())
+				return
+			}
+			w.Write(b2)
+			listsMu.Unlock()
 
-            setsMu.Lock()
-            b3, err := json.MarshalIndent(&allSets, "", "    ")
-            if err != nil {
-                println(err.Error())
-                return
-            }
-            w.Write(b3)
-            setsMu.Unlock()
+			setsMu.Lock()
+			b3, err := json.MarshalIndent(&allSets, "", "    ")
+			if err != nil {
+				println(err.Error())
+				return
+			}
+			w.Write(b3)
+			setsMu.Unlock()
 
-            stringsMu.Lock()
-            b4, err := json.MarshalIndent(&allStrings, "", "    ")
-            if err != nil {
-                println(err.Error())
-                return
-            }
-            w.Write(b4)
-            stringsMu.Unlock()
+			stringsMu.Lock()
+			b4, err := json.MarshalIndent(&allStrings, "", "    ")
+			if err != nil {
+				println(err.Error())
+				return
+			}
+			w.Write(b4)
+			stringsMu.Unlock()
 
-            w.Flush()
+			w.Flush()
 
-            if complete != nil {
-                complete <- true
-            }
-        }()
-    }
+			if complete != nil {
+				complete <- true
+			}
+		}()
+	}
 
-    return "OK"
+	return "OK"
 }
 
 //// Load any backup before doing anything else.
 //
 func InitDB(fileName string) {
-    if fileName != "" {
-        fileWriteMu.Lock()
-        defer fileWriteMu.Unlock()
+	if fileName != "" {
+		fileWriteMu.Lock()
+		defer fileWriteMu.Unlock()
 
-        fo, _ := os.Open(fileName)
-        defer fo.Close()
+		fo, _ := os.Open(fileName)
+		defer fo.Close()
 
-        r := bufio.NewReader(fo)
-        dec := json.NewDecoder(r)
+		r := bufio.NewReader(fo)
+		dec := json.NewDecoder(r)
 
-        hashesMu.Lock()
-        dec.Decode(&allHashes)
-        hashesMu.Unlock()
+		hashesMu.Lock()
+		dec.Decode(&allHashes)
+		hashesMu.Unlock()
 
-        listsMu.Lock()
-        dec.Decode(&allLists)
-        listsMu.Unlock()
+		listsMu.Lock()
+		dec.Decode(&allLists)
+		listsMu.Unlock()
 
-        setsMu.Lock()
-        dec.Decode(&allSets)
-        setsMu.Unlock()
+		setsMu.Lock()
+		dec.Decode(&allSets)
+		setsMu.Unlock()
 
-        stringsMu.Lock()
-        dec.Decode(&allStrings)
-        stringsMu.Unlock()
-    }
+		stringsMu.Lock()
+		dec.Decode(&allStrings)
+		stringsMu.Unlock()
+	}
 }

--- a/server.go
+++ b/server.go
@@ -51,27 +51,27 @@ func BgSave(fileName string, complete chan bool) string {
 			}
 			w.Write(b1)
 
-			listsMu.Lock()
+			listsMu.RLock()
 			b2, err := json.MarshalIndent(&allLists, "", "    ")
-			listsMu.Unlock()
+			listsMu.RUnlock()
 			if err != nil {
 				println(err.Error())
 				return
 			}
 			w.Write(b2)
 
-			setsMu.Lock()
+			setsMu.RLock()
 			b3, err := json.MarshalIndent(&allSets, "", "    ")
-			setsMu.Unlock()
+			setsMu.RUnlock()
 			if err != nil {
 				println(err.Error())
 				return
 			}
 			w.Write(b3)
 
-			stringsMu.Lock()
+			stringsMu.RLock()
 			b4, err := json.MarshalIndent(&allStrings, "", "    ")
-			stringsMu.Unlock()
+			stringsMu.RUnlock()
 			if err != nil {
 				println(err.Error())
 				return


### PR DESCRIPTION
There are many shared data structures that are mutated at the same time when returned from the in-memory implementation. This patch converts them to getters and setters that are behind mutexes. 

It also updates usage of existing `RWMutex` instance to use the read lock instead of the write lock when only a read is taking place.

Changes here will break `art-spigot` until the corresponding `fix_data_races` branch is also merged in that project.