### PR TITLE
HDel should always publish a valid Hash instance

### DIFF
--- a/hashes.go
+++ b/hashes.go
@@ -21,6 +21,11 @@ func NewHash() Hash {
 	}
 }
 
+// Valid returns true if the Hash is a valid non-nil instance
+func (h Hash) Valid() bool {
+	return h.m != nil && h.mu != nil
+}
+
 // Size returns the number of items in the hash
 func (h Hash) Size() int {
 	h.mu.RLock()
@@ -181,6 +186,9 @@ func HDel(key, field string) (existed int) {
 			h.Delete(field)
 			existed++
 		}
+	} else {
+		// Publish a valid empty Hash
+		h = NewHash()
 	}
 
 	hashesMu.Unlock()


### PR DESCRIPTION
Fixes https://github.com/AnimationMentor/art-spigot/issues/9

`HDel()` would publish a `nil` `Hash`, causing consumers to panic when trying to assert and then access the `Hash`

Also added a `Hash.Valid()` method so that a consumer can check this state. It is otherwise impossible to check because every other public method tries to access the fields.